### PR TITLE
1.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,41 @@ Software should be easy to install, so we've provided you with some shortcuts to
 
 ### Package Installs
 
-#### macOS
-Download and install using ZIP packages
+#### macOS / 'nix
+
+Note: Search is not installed by default anymore, if you would like search then supply `-s` to the installer script.
+
+Options:
+
+* `s` - Include the search engine. (Without it, we will fallback to database searches)
+* `z` - Use the zip install
+* `h` - Show the help text
+
+Environment variables:
+
+* `TARGET_DIR` - The location to install the zip (Defaults to `$PWD/fusionauth`)
+* `VERSION` - The version to install (Defaults to latest stable version)
+
+##### Examples
+
+Download and install (Automatic method will choose RPM, DEB, or ZIP depending on the available package manager)
 ```bash
 sh -c "curl -fsSL https://raw.githubusercontent.com/FusionAuth/fusionauth-install/master/install.sh | sh"
 ```
 
-#### Linux
-Download and install RPM or DEB packages
+Download and install with search
 ```bash
-sh -c "curl -fsSL https://raw.githubusercontent.com/FusionAuth/fusionauth-install/master/install.sh | sh"
+sh -c "curl -fsSL https://raw.githubusercontent.com/FusionAuth/fusionauth-install/master/install.sh | sh -s - -s"
 ```
 
 Download and install ZIP packages to current directory
 ```bash
 sh -c "curl -fsSL https://raw.githubusercontent.com/FusionAuth/fusionauth-install/master/install.sh | sh -s - -z"
+```
+
+Download and install ZIP packages (with search) to current directory
+```bash
+sh -c "curl -fsSL https://raw.githubusercontent.com/FusionAuth/fusionauth-install/master/install.sh | sh -s - -zs"
 ```
 
 #### Windows

--- a/README.md
+++ b/README.md
@@ -42,10 +42,15 @@ sh -c "curl -fsSL https://raw.githubusercontent.com/FusionAuth/fusionauth-instal
 ```
 
 #### Windows
-Download and install using ZIP packages
 
+Download and install using ZIP packages
 ```powershell
-iex (new-object net.webclient).downloadstring('https://raw.githubusercontent.com/FusionAuth/fusionauth-install/master/install.ps1')
+. { iwr -useb https://raw.githubusercontent.com/FusionAuth/fusionauth-install/master/install.ps1 } | iex; install
+```
+
+Install with search
+```powershell
+. { iwr -useb https://raw.githubusercontent.com/FusionAuth/fusionauth-install/master/install.ps1 } | iex; install -includeSearch 1
 ```
 
 If you run into an error, you may need to change your execution policy. `Set-ExecutionPolicy Bypass -scope CurrentUser`
@@ -87,5 +92,4 @@ Ubuntu, Centos, and Windows testing have been automated via vagrant, go to the r
 
 To test a system go to the related directory and run `vagrant up`. You can then visit http://localhost:9011 in your systems browser (on the host) and see if fusionauth started up properly.
 
-Macos could potentially be tested the same way, but the vagrant boxes aren't legally allowed to be distributed this way so you would have to make your own.
- 
+Macos could potentially be tested the same way, but the vagrant boxes aren't legally allowed to be distributed this way, so you would have to make your own. 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Software should be easy to install, so we've provided you with some shortcuts to
 
 #### macOS / 'nix
 
-Note: Search is not installed by default anymore, if you would like search then supply `-s` to the installer script.
+Note: Search is no longer installed by default anymore, if you would like search then supply `-s` to the installer script.
 
 Options:
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,80 +1,106 @@
-# Get current setting
-$old_erroractionpreference = $erroractionpreference
-$erroractionpreference = 'stop' # quit if anything goes wrong
+new-module -name FusionAuth -scriptblock {
+    function Install-FusionAuth()
+    {
+        param (# This must come first
+            [bool]$includeSearch = 0
+        )
 
-# Try importing BitsTransfer
-if (!(Get-module BitsTransfer)) {
-    Import-Module BitsTransfer -ErrorAction SilentlyContinue
-}
+        # Get current setting
+        $old_erroractionpreference = $erroractionpreference
+        $erroractionpreference = 'stop' # quit if anything goes wrong
 
-if(($PSVersionTable.PSVersion.Major) -lt 5) {
-    Write-Output "PowerShell 5 or greater is required to run this installer."
-    Write-Output "Upgrade PowerShell: https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell"
-    break
-}
+        # Try importing BitsTransfer
+        if (!(Get-module BitsTransfer))
+        {
+            Import-Module BitsTransfer -ErrorAction SilentlyContinue
+        }
 
-function DownloadAndExpandZip($uri, $tempFile, $destination) {
-    Write-Output "Downloading archive, destination ${destination}"
+        if (($PSVersionTable.PSVersion.Major) -lt 5)
+        {
+            Write-Output "PowerShell 5 or greater is required to run this installer."
+            Write-Output "Upgrade PowerShell: https://docs.microsoft.com/en-us/powershell/scripting/setup/installing-windows-powershell"
+            break
+        }
 
-    if (Get-module BitsTransfer) {
-        Start-BitsTransfer -Source $uri -Destination $tempFile
-    } else {
-        (New-Object System.Net.WebClient).DownloadFile($uri, $tempFile)
+        function DownloadAndExpandZip($uri, $tempFile, $destination)
+        {
+            Write-Output "Downloading archive, destination ${destination}"
+
+            if (Get-module BitsTransfer)
+            {
+                Start-BitsTransfer -Source $uri -Destination $tempFile
+            }
+            else
+            {
+                (New-Object System.Net.WebClient).DownloadFile($uri, $tempFile)
+            }
+
+            Write-Output "Expanding archive"
+
+            if (Test-Path "$env:Temp/fusionauth")
+            {
+                Remove-Item -Force -Recurse "$env:Temp/fusionauth"
+            }
+
+            New-Item "$env:Temp/fusionauth" -ItemType Directory
+
+            Expand-Archive -Path $tempFile -DestinationPath "$env:Temp/fusionauth"
+
+            New-Item $destination -ItemType Directory -ea 0
+
+            robocopy "$env:Temp/fusionauth" $destination /E /XC /XN /XO /NFL /NDL /NJH /NS /NC
+        }
+
+        $BASE_URL = "https://storage.googleapis.com/inversoft_products_j098230498/products/fusionauth"
+#        $BASE_URL = "http://bundles.local.fusionauth.io"
+        $VERSION = Invoke-WebRequest -UseBasicParsing -Uri https://metrics.fusionauth.io/api/latest-version
+#        $VERSION = "1.16.0-RC.2"
+        # Trim the trailing \ since we add it when we set the destination directory, and it may come back on the FullName property
+        #  > C:\> (Get-Item -Path ".\").FullName       => C:\
+        #  > C:\foo> (Get-Item -Path ".\").FullName    => C:\foo
+        $CURRENT_DIRECTORY = (Get-Item -Path ".\").FullName.TrimEnd("\")
+
+        Write-Output "Install FusionAuth version ${VERSION}"
+
+        if (Test-Path "$CURRENT_DIRECTORY\fusionauth\fusionauth-app")
+        {
+            Remove-Item -Force -Recurse "$CURRENT_DIRECTORY\fusionauth\fusionauth-app"
+        }
+        if (Test-Path "$CURRENT_DIRECTORY\fusionauth\fusionauth-search")
+        {
+            Remove-Item -Force -Recurse "$CURRENT_DIRECTORY\fusionauth\fusionauth-search"
+        }
+        if (Test-Path "$CURRENT_DIRECTORY\fusionauth\bin")
+        {
+            Remove-Item -Force -Recurse "$CURRENT_DIRECTORY\fusionauth\bin"
+        }
+
+        echo "Installing zip packages"
+
+        # Install search first so that we get the search version of fusionauth.properties (which enables search)
+        if ($includeSearch)
+        {
+            DownloadAndExpandZip "${BASE_URL}/${VERSION}/fusionauth-search-${VERSION}.zip" "$env:Temp\fusionauth-search.zip" "$CURRENT_DIRECTORY\fusionauth"
+        }
+        DownloadAndExpandZip "${BASE_URL}/${VERSION}/fusionauth-app-${VERSION}.zip" "$env:Temp\fusionauth-app.zip" "$CURRENT_DIRECTORY\fusionauth"
+
+        Write-Output ""
+        Write-Output "Install is complete. Time for tacos."
+        Write-Output ""
+        Write-Output " 1. To start FusionAuth run the following command"
+        Write-Output "    .\fusionauth\bin\startup.bat"
+        Write-Output ""
+        Write-Output " 2. To begin, access FusionAuth by opening a browser to http://localhost:9011"
+        Write-Output ""
+        Write-Output " 3. If you're looking for documentation, open your browser and navigate to https://fusionauth.io/docs"
+        Write-Output ""
+        Write-Output "Thank you have a nice day."
+
+        # Restore old setting
+        $erroractionpreference = $old_erroractionpreference # Reset $erroractionpreference to original value
     }
 
-    Write-Output "Expanding archive"
+    set-alias install -value Install-FusionAuth
 
-    if (Test-Path "$env:Temp/fusionauth") {
-        Remove-Item -Force -Recurse "$env:Temp/fusionauth"
-    }
-
-    New-Item "$env:Temp/fusionauth" -ItemType Directory
-
-    Expand-Archive -Path $tempFile -DestinationPath "$env:Temp/fusionauth"
-
-    New-Item $destination -ItemType Directory -ea 0
-
-    robocopy "$env:Temp/fusionauth" $destination /E /XC /XN /XO /NFL /NDL /NJH /NS /NC
+    export-modulemember -function Install-FusionAuth -alias install
 }
-
-$BASE_URL = "https://storage.googleapis.com/inversoft_products_j098230498/products/fusionauth"
-# $BASE_URL = "http://bundles.local.fusionauth.io"
-$VERSION = Invoke-WebRequest -UseBasicParsing -Uri https://metrics.fusionauth.io/api/latest-version
-# $VERSION = "1.16.0"
-# Trim the trailing \ since we add it when we set the destination directory, and it may come back on the FullName property
-#  > C:\> (Get-Item -Path ".\").FullName       => C:\
-#  > C:\foo> (Get-Item -Path ".\").FullName    => C:\foo
-$CURRENT_DIRECTORY=(Get-Item -Path ".\").FullName.TrimEnd("\")
-
-Write-Output "Install FusionAuth version ${VERSION}"
-
-if (Test-Path "$CURRENT_DIRECTORY\fusionauth\fusionauth-app") {
-    Remove-Item -Force -Recurse "$CURRENT_DIRECTORY\fusionauth\fusionauth-app"
-}
-if (Test-Path "$CURRENT_DIRECTORY\fusionauth\fusionauth-search") {
-    Remove-Item -Force -Recurse "$CURRENT_DIRECTORY\fusionauth\fusionauth-search"
-}
-if (Test-Path "$CURRENT_DIRECTORY\fusionauth\bin") {
-    Remove-Item -Force -Recurse "$CURRENT_DIRECTORY\fusionauth\bin"
-}
-
-echo "Installing zip packages"
-
-
-DownloadAndExpandZip "${BASE_URL}/${VERSION}/fusionauth-app-${VERSION}.zip" "$env:Temp\fusionauth-app.zip" "$CURRENT_DIRECTORY\fusionauth"
-DownloadAndExpandZip "${BASE_URL}/${VERSION}/fusionauth-search-${VERSION}.zip" "$env:Temp\fusionauth-search.zip" "$CURRENT_DIRECTORY\fusionauth"
-
-Write-Output ""
-Write-Output "Install is complete. Time for tacos."
-Write-Output ""
-Write-Output " 1. To start FusionAuth run the following command"
-Write-Output "    .\fusionauth\bin\startup.bat"
-Write-Output ""
-Write-Output " 2. To begin, access FusionAuth by opening a browser to http://localhost:9011"
-Write-Output ""
-Write-Output " 3. If you're looking for documentation, open your browser and navigate to https://fusionauth.io/docs"
-Write-Output ""
-Write-Output "Thank you have a nice day."
-
-# Restore old setting
-$erroractionpreference = $old_erroractionpreference # Reset $erroractionpreference to original value

--- a/install.sh
+++ b/install.sh
@@ -64,7 +64,7 @@ install_deb() {
 
     curl -fSL --progress-bar -o /tmp/fusionauth-app.deb "${BASE_URL}/${VERSION}/fusionauth-app_${VERSION}-1_all.deb"
 
-    if [ $INCLUDE_SEARCH == 1 ]; then
+    if [ $INCLUDE_SEARCH -eq 1 ]; then
       curl -fSL --progress-bar -o /tmp/fusionauth-search.deb "${BASE_URL}/${VERSION}/fusionauth-search_${VERSION}-1_all.deb"
       packages="$packages /tmp/fusionauth-search.deb"
     fi
@@ -72,7 +72,7 @@ install_deb() {
     echo "Installing deb packages"
 
     # Install search first so that we get the search version of fusionauth.properties
-    if [ $INCLUDE_SEARCH == 1 ]; then
+    if [ $INCLUDE_SEARCH -eq 1 ]; then
       echo "sudo dpkg -i /tmp/fusionauth-search.deb"
       sudo dpkg -i /tmp/fusionauth-search.deb
     fi
@@ -98,14 +98,14 @@ install_rpm() {
 
     curl -fSL --progress-bar -o /tmp/fusionauth-app.rpm "${BASE_URL}/${VERSION}/fusionauth-app-${VERSION//-/.}-1.noarch.rpm"
 
-    if [ $INCLUDE_SEARCH == 1 ]; then
+    if [ $INCLUDE_SEARCH -eq 1 ]; then
       curl -fSL --progress-bar -o /tmp/fusionauth-search.rpm "${BASE_URL}/${VERSION}/fusionauth-search-${VERSION//-/.}-1.noarch.rpm"
     fi
 
     echo "Installing rpm packages"
 
     # Install search first so that we get the search version of fusionauth.properties
-    if [ $INCLUDE_SEARCH == 1 ]; then
+    if [ $INCLUDE_SEARCH -eq 1 ]; then
       echo "sudo rpm -U /tmp/fusionauth-search.rpm"
       sudo rpm -U /tmp/fusionauth-search.rpm
     fi
@@ -136,7 +136,7 @@ install_zip() {
 
     curl -fSL --progress-bar -o /tmp/fusionauth-app.zip "${BASE_URL}/${VERSION}/fusionauth-app-${VERSION}.zip"
 
-    if [ $INCLUDE_SEARCH == 1 ]; then
+    if [ $INCLUDE_SEARCH -eq 1 ]; then
       curl -fSL --progress-bar -o /tmp/fusionauth-search.zip "${BASE_URL}/${VERSION}/fusionauth-search-${VERSION}.zip"
     fi
 
@@ -152,7 +152,7 @@ install_zip() {
     echo "Installing packages"
 
     # Install search first so that we get the search version of fusionauth.properties
-    if [ $INCLUDE_SEARCH == 1 ]; then
+    if [ $INCLUDE_SEARCH -eq 1 ]; then
       unzip -nq /tmp/fusionauth-search.zip -d ${TARGET_DIR}
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -62,8 +62,6 @@ install_linux() {
 install_deb() {
     echo "Downloading deb packages"
 
-    packages="/tmp/fusionauth-app.deb"
-
     curl -fSL --progress-bar -o /tmp/fusionauth-app.deb "${BASE_URL}/${VERSION}/fusionauth-app_${VERSION}-1_all.deb"
 
     if [ $INCLUDE_SEARCH == 1 ]; then
@@ -72,8 +70,15 @@ install_deb() {
     fi
 
     echo "Installing deb packages"
-    # shellcheck disable=SC2086
-    sudo dpkg -i $packages
+
+    # Install search first so that we get the search version of fusionauth.properties
+    if [ $INCLUDE_SEARCH == 1 ]; then
+      echo "sudo dpkg -i /tmp/fusionauth-search.deb"
+      sudo dpkg -i /tmp/fusionauth-search.deb
+    fi
+
+    echo "sudo dpkg -i /tmp/fusionauth-app.deb"
+    sudo dpkg -i /tmp/fusionauth-app.deb
 
     # Ensure we completed the sudo request
     if [  $? -ne 0 ] ; then
@@ -91,18 +96,22 @@ install_deb() {
 install_rpm() {
     echo "Downloading RPM packages"
 
-    packages="/tmp/fusionauth-app.rpm"
-
     curl -fSL --progress-bar -o /tmp/fusionauth-app.rpm "${BASE_URL}/${VERSION}/fusionauth-app-${VERSION//-/.}-1.noarch.rpm"
 
     if [ $INCLUDE_SEARCH == 1 ]; then
       curl -fSL --progress-bar -o /tmp/fusionauth-search.rpm "${BASE_URL}/${VERSION}/fusionauth-search-${VERSION//-/.}-1.noarch.rpm"
-      packages="$packages /tmp/fusionauth-search.rpm"
     fi
 
     echo "Installing rpm packages"
-    # shellcheck disable=SC2086
-    sudo rpm -U $packages
+
+    # Install search first so that we get the search version of fusionauth.properties
+    if [ $INCLUDE_SEARCH == 1 ]; then
+      echo "sudo rpm -U /tmp/fusionauth-search.rpm"
+      sudo rpm -U /tmp/fusionauth-search.rpm
+    fi
+
+    echo "sudo rpm -U /tmp/fusionauth-app.rpm"
+    sudo rpm -U /tmp/fusionauth-app.rpm
 
     # Ensure we completed the sudo request
     if [  $? -ne 0 ] ; then
@@ -142,11 +151,12 @@ install_zip() {
 
     echo "Installing packages"
 
-    unzip -nq /tmp/fusionauth-app.zip -d ${TARGET_DIR}
-
+    # Install search first so that we get the search version of fusionauth.properties
     if [ $INCLUDE_SEARCH == 1 ]; then
       unzip -nq /tmp/fusionauth-search.zip -d ${TARGET_DIR}
     fi
+
+    unzip -nq /tmp/fusionauth-app.zip -d ${TARGET_DIR}
 
     echo ""
     echo "Install is complete. Time for tacos."

--- a/test/centos/Vagrantfile
+++ b/test/centos/Vagrantfile
@@ -64,11 +64,24 @@ Vagrant.configure("2") do |config|
   # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "file", source: "install.sh", destination: "install.sh"
+  # Use one of the following:
+  ## With search
   config.vm.provision "shell", inline: <<-SHELL
     echo "10.0.2.2 bundles.local.fusionauth.io" >> /etc/hosts
-    ./install.sh
+    VERSION=1.16.0-RC.1 ./install.sh -s
     service fusionauth-app start
     service fusionauth-search start
   SHELL
+  ## Without search (default)
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   echo "10.0.2.2 bundles.local.fusionauth.io" >> /etc/hosts
+  #   VERSION=1.16.0-RC.1 ./install.sh
+  #   service fusionauth-app start
+  # SHELL
+  ## Zip
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   VERSION=1.16.0-RC.1 ./install.sh -z
+  #   ./fusionauth/bin/startup.sh
+  # SHELL
 
 end

--- a/test/ubuntu/Vagrantfile
+++ b/test/ubuntu/Vagrantfile
@@ -66,12 +66,12 @@ Vagrant.configure("2") do |config|
   config.vm.provision "file", source: "install.sh", destination: "install.sh"
   # Use one of the following:
   ## With search
-  config.vm.provision "shell", inline: <<-SHELL
-    echo "10.0.2.2 bundles.local.fusionauth.io" >> /etc/hosts
-    VERSION=1.16.0-RC.1 ./install.sh -s
-    service fusionauth-app start
-    service fusionauth-search start
-  SHELL
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   echo "10.0.2.2 bundles.local.fusionauth.io" >> /etc/hosts
+  #   VERSION=1.16.0-RC.1 ./install.sh -s
+  #   service fusionauth-app start
+  #   service fusionauth-search start
+  # SHELL
   ## Without search (default)
   # config.vm.provision "shell", inline: <<-SHELL
   #   echo "10.0.2.2 bundles.local.fusionauth.io" >> /etc/hosts
@@ -83,5 +83,11 @@ Vagrant.configure("2") do |config|
   #   VERSION=1.16.0-RC.1 ./install.sh -z
   #   ./fusionauth/bin/startup.sh
   # SHELL
+  ## Production
+  config.vm.provision "shell", inline: <<-SHELL
+    sh -c "curl -fsSL https://raw.githubusercontent.com/FusionAuth/fusionauth-install/1.16.0/install.sh | sh"
+    service fusionauth-app start
+    service fusionauth-search start
+  SHELL
 
 end

--- a/test/ubuntu/Vagrantfile
+++ b/test/ubuntu/Vagrantfile
@@ -64,11 +64,24 @@ Vagrant.configure("2") do |config|
   # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "file", source: "install.sh", destination: "install.sh"
+  # Use one of the following:
+  ## With search
   config.vm.provision "shell", inline: <<-SHELL
     echo "10.0.2.2 bundles.local.fusionauth.io" >> /etc/hosts
-    ./install.sh
+    VERSION=1.16.0-RC.1 ./install.sh -s
     service fusionauth-app start
     service fusionauth-search start
   SHELL
+  ## Without search (default)
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   echo "10.0.2.2 bundles.local.fusionauth.io" >> /etc/hosts
+  #   VERSION=1.16.0-RC.1 ./install.sh
+  #   service fusionauth-app start
+  # SHELL
+  ## Zip
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   VERSION=1.16.0-RC.1 ./install.sh -z
+  #   ./fusionauth/bin/startup.sh
+  # SHELL
 
 end

--- a/test/ubuntu/Vagrantfile
+++ b/test/ubuntu/Vagrantfile
@@ -85,7 +85,7 @@ Vagrant.configure("2") do |config|
   # SHELL
   ## Production
   config.vm.provision "shell", inline: <<-SHELL
-    sh -c "curl -fsSL https://raw.githubusercontent.com/FusionAuth/fusionauth-install/1.16.0/install.sh | sh"
+    sh -c "curl -fsSL https://raw.githubusercontent.com/FusionAuth/fusionauth-install/1.16.0/install.sh | sh -s - -s"
     service fusionauth-app start
     service fusionauth-search start
   SHELL

--- a/test/windows/Vagrantfile
+++ b/test/windows/Vagrantfile
@@ -74,11 +74,16 @@ Vagrant.configure("2") do |config|
   #   ./fusionauth/bin/startup.bat
   # SHELL
   ## With search
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   Add-Content -Value "10.0.2.2 bundles.local.fusionauth.io" -Path C:/Windows/System32/drivers/etc/hosts
+  #   cd /Users/vagrant
+  #   ./install.ps1; install -includeSearch 1
+  #   ./fusionauth/bin/startup.bat
+  # SHELL
+  ## Production
   config.vm.provision "shell", inline: <<-SHELL
-    Add-Content -Value "10.0.2.2 bundles.local.fusionauth.io" -Path C:/Windows/System32/drivers/etc/hosts
     cd /Users/vagrant
-    ./install.ps1; install -includeSearch 1
+    . { iwr -useb https://raw.githubusercontent.com/FusionAuth/fusionauth-install/1.16.0/install.ps1 } | iex; install
     ./fusionauth/bin/startup.bat
   SHELL
-
 end

--- a/test/windows/Vagrantfile
+++ b/test/windows/Vagrantfile
@@ -65,10 +65,19 @@ Vagrant.configure("2") do |config|
   # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "file", source: "install.ps1", destination: "C:/Users/vagrant/install.ps1"
+  # Use only one of the following
+  ## Without search
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   Add-Content -Value "10.0.2.2 bundles.local.fusionauth.io" -Path C:/Windows/System32/drivers/etc/hosts
+  #   cd /Users/vagrant
+  #   ./install.ps1; install
+  #   ./fusionauth/bin/startup.bat
+  # SHELL
+  ## With search
   config.vm.provision "shell", inline: <<-SHELL
     Add-Content -Value "10.0.2.2 bundles.local.fusionauth.io" -Path C:/Windows/System32/drivers/etc/hosts
     cd /Users/vagrant
-    ./install.ps1
+    ./install.ps1; install -includeSearch 1
     ./fusionauth/bin/startup.bat
   SHELL
 


### PR DESCRIPTION
Dependencies:
* `1.16.0` is released - This script depends on `1.16.0` GA because release candidates are not returned by the latest version API. This means that the script would try to install `1.15.8` without a search engine by default which would break installs.

Required steps:

* [ ] Do full test using url (you can modify the url to point at the branch and it will be equivalent)
* [ ] Merge this branch
* [ ] Update site to reflect new windows install method
* [ ] Update doc to reflect new windows install method

Closes #3 