### PR TITLE
Update Readme to Reflect Windows Users Needing PowerShell to Install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ sh -c "curl -fsSL https://raw.githubusercontent.com/FusionAuth/fusionauth-instal
 
 #### Windows
 
-Download and install using ZIP packages
+Download and install using ZIP packages.  Install using Windows PowerShell
 ```powershell
 . { iwr -useb https://raw.githubusercontent.com/FusionAuth/fusionauth-install/master/install.ps1 } | iex; install
 REM Optionally register the service with the following commands
@@ -51,7 +51,7 @@ cd fusionauth\fusionauth-app\apache-tomcat\bin
 FusionAuthApp.exe /install
 ```
 
-Download and install with Elasticsearch using ZIP packages
+Download and install with Elasticsearch using ZIP packages.  Install using Windows PowerShell
 ```powershell
 . { iwr -useb https://raw.githubusercontent.com/FusionAuth/fusionauth-install/master/install.ps1 } | iex; install -includeSearch 1
 REM Optionally register the service with the following commands


### PR DESCRIPTION
# Summary
- This updates the installation instructions for Windows users to indicate that PowerShell must be used to install (as opposed to the command prompt, etc)

# Screenshot
![Screen Shot 2021-03-16 at 9 42 07 AM](https://user-images.githubusercontent.com/16090626/111337727-ee0db400-863b-11eb-897f-ddc20a55cdf1.png)
